### PR TITLE
Update FindNumPy.cmake

### DIFF
--- a/cmake/FindNumPy.cmake
+++ b/cmake/FindNumPy.cmake
@@ -16,7 +16,7 @@ FIND_PACKAGE(PythonInterp REQUIRED)
 
 # Look for the include path
 # WARNING: The variable PYTHON_EXECUTABLE is defined by the script FindPythonInterp.cmake
-EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" -c "import numpy; print numpy.get_include(); print numpy.version.version"
+EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" -c "import numpy; print(numpy.get_include()); print(numpy.version.version)"
                  OUTPUT_VARIABLE NUMPY_OUTPUT
                  ERROR_VARIABLE NUMPY_ERROR)
                  


### PR DESCRIPTION
print() parenthesis are forced in Python3. This should work for both versions.