### PR TITLE
Changed every xrange() to range() for compatibility with Python 3

### DIFF
--- a/modules/base/test/python/nodeTest.py
+++ b/modules/base/test/python/nodeTest.py
@@ -33,7 +33,7 @@ class NodeTest(unittest.TestCase):
         
     def test_copy_variable_in_cell(self):
         nodes = [];
-        for i in xrange(0,3):
+        for i in range(0,3):
             node = ma.Node('Node'+str(i+1));
             nodes.append(node);
         self.assertEqual(nodes[0].name(), 'Node1');

--- a/modules/instrument/test/python/forceplatetype5Test.py
+++ b/modules/instrument/test/python/forceplatetype5Test.py
@@ -80,7 +80,7 @@ class ForcePlateType5Test(unittest.TestCase):
         self.assertEqual(cmdim[0], 6)
         self.assertEqual(cmdim[1], 8)
         cmdata = fp5.calibrationMatrixData()
-        for i in xrange(0,48):
+        for i in range(0,48):
             self.assertAlmostEqual(cmdata[i], fp5_calib6x8[i], 5)
     
     def test_wrenches(self):
@@ -130,7 +130,7 @@ class ForcePlateType5Test(unittest.TestCase):
         
         # NOTE: Tolerance are higher than in the C++ due to the difference in the method to compare real numbers.
         wlo = fp5.wrench(ma.instrument.Location_Origin, False).data()
-        for i in xrange(0,samples):
+        for i in range(0,samples):
             self.assertAlmostEqual(wlo[i,0], -fp5_dataout[i+0*samples], 3)
             self.assertAlmostEqual(wlo[i,1], -fp5_dataout[i+1*samples], 3)
             self.assertAlmostEqual(wlo[i,2], -fp5_dataout[i+2*samples], 3) 
@@ -138,7 +138,7 @@ class ForcePlateType5Test(unittest.TestCase):
             self.assertAlmostEqual(wlo[i,4]/1000., -fp5_dataout[i+4*samples], 3)
             self.assertAlmostEqual(wlo[i,5]/1000., -fp5_dataout[i+5*samples], 3)
         wlc = fp5.wrench(ma.instrument.Location_CentreOfPressure, False).data()
-        for i in xrange(0,samples):
+        for i in range(0,samples):
             self.assertAlmostEqual(wlc[i,6], fp5_dataout[i+6*samples], 2)
             self.assertAlmostEqual(wlc[i,7], fp5_dataout[i+7*samples], 2)
             self.assertAlmostEqual(wlc[i,8], fp5_dataout[i+8*samples]-16.33887, 2)

--- a/modules/io/test/python/ioTest.py
+++ b/modules/io/test/python/ioTest.py
@@ -12,7 +12,7 @@ class IOTest(unittest.TestCase):
         root = ma.io.read(openma_tdd_path_in('c3d/standard/sample01/Eb015vi.c3d'))
         forceplates = root.findChildren(ma.instrument.T_ForcePlate)
         self.assertEqual(len(forceplates),2)
-        for i in xrange(0,2):
+        for i in range(0,2):
             fp = forceplates[i]
             self.assertEqual(fp.type(), 2)
             self.assertEqual(fp.type(), ma.instrument.ForcePlate.Type_Type2)

--- a/modules/processing/test/python/processingTest.py
+++ b/modules/processing/test/python/processingTest.py
@@ -10,7 +10,7 @@ class ProcessingTest(unittest.TestCase):
         ts.setData(np.array([data]).T)
         self.assertEqual(ma.processing.filter_butterworth_zero_lag([ts],ma.processing.Response_LowPass,20.0,2), True)
         out = ts.data()
-        for i in xrange(0,81):
+        for i in range(0,81):
             self.assertAlmostEqual(out[i], ref[i], 7)
         
     def test_butterworth_zero_lag_low_pass_reconstructed(self):
@@ -24,7 +24,7 @@ class ProcessingTest(unittest.TestCase):
         self.assertEqual(ma.processing.filter_butterworth_zero_lag(tss,ma.processing.Response_LowPass,6.0,4), True)
         out1 = tss[0].data()
         out2 = tss[1].data()
-        for i in xrange(0,81):
+        for i in range(0,81):
             self.assertAlmostEqual(out1[i][0], ref[0][i], 7)
             self.assertAlmostEqual(out1[i][1], ref[0][i], 7)
             self.assertAlmostEqual(out1[i][2], ref[0][i], 7)


### PR DESCRIPTION
Even though it's not an iterator in Python 2, the lists are pretty small, and used for testing. No big performance penalties I guess.